### PR TITLE
Fix hash for stage 38

### DIFF
--- a/data/levels/hackit38.php
+++ b/data/levels/hackit38.php
@@ -52,8 +52,8 @@ sha1 = ( "'.$_SESSION['string1'][basename(__FILE__, '.php')].'" + "'.$_SESSION['
 </code></pre><br/>
 
 <strong>Example:</strong><br/>
-nonce = "132f4c5f0f"<br/>
-sha1("string1"+"string2"+nonce) -> Results in sha1 hash 000000593a640078a309840d69b4e2064d09ae20 so 132f4c5f0f would be the solution if we were looking for 6 leading zeroes
+nonce = "dnt28wclnx"<br/>
+sha1("string1"+"string2"+nonce) -> Results in sha1 hash 000000140e9731bbf369d8cbc4f7919961020793 so dnt28wclnx would be a solution if we were looking for 6 leading zeroes
 <br/><br/>
             Solution:<br/><input id="pw" type="password" />
             <br/><input type="button" value="OK" onClick="checkPW()"/>


### PR DESCRIPTION
As mentioned in #12 

```
<?php
echo sha1("string1"."string2"."132f4c5f0f");
```

Prints`997ffa731506ee6d66dfafe17dbdf76316e2e67b` which does not start with 6 leading zeros.

I've updated it to use an answer of `dnt28wclnx` which results in a hash of `000000140e9731bbf369d8cbc4f7919961020793` which satisfies the problem.

```
<?php
echo sha1("string1"."string2"."dnt28wclnx");
```